### PR TITLE
Option to configure the label of the 'Run in terminal' button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This file is structured according to the [Keep a Changelog](http://keepachangelo
 ### Added
 
 - Added support for HTML tag attributes (with markdown-it-attrs)
+- Option to configure the ▶️ label of the 'Run in terminal' button
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -31,10 +31,11 @@ that gives you nice <kbd>▶️</kbd> _Run in terminal_ buttons for your code bl
 
 ## Extension Settings
 
-| Setting                     | Description                                                  | Options                           |
+| Setting                     | Description                                                  | Options/Default                   |
 |-----------------------------|--------------------------------------------------------------|-----------------------------------|
-| `tothom.colorScheme`        | Color scheme of the preview panel                            | `auto` (default), `light`, `dark` |
 | `tothom.bracketedPasteMode` | Apply bracketed paste sequences on commands sent to terminal | `true` (default), `false`         |
+| `tothom.colorScheme`        | Color scheme of the preview panel                            | `auto` (default), `light`, `dark` |
+| `tothom.runInTerminalLabel` | Label of the _Run in terminal_ button                        | Default: `▶️`                      |
 
 ## Limitations
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,11 @@
       {
         "title": "Tothom",
         "properties": {
+          "tothom.bracketedPasteMode": {
+            "description": "Apply bracketed paste sequences on commands sent to terminal",
+            "type": "boolean",
+            "default": true
+          },
           "tothom.colorScheme": {
             "description": "Color scheme of the preview panel",
             "type": "string",
@@ -53,10 +58,10 @@
               "Dark color scheme"
             ]
           },
-          "tothom.bracketedPasteMode": {
-            "description": "Apply bracketed paste sequences on commands sent to terminal",
-            "type": "boolean",
-            "default": true
+          "tothom.runInTerminalLabel": {
+            "description": "Label of the 'Run in terminal' button",
+            "type": "string",
+            "default": "▶️"
           }
         }
       }

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -3,71 +3,108 @@ import hljs from 'highlight.js';
 import * as terminal from './terminal';
 import { slugify } from './slugify';
 
-const syntaxHighlight = (code: string, language: string): string => {
-  if (language && hljs.getLanguage(language)) {
-    try {
-      return hljs.highlight(code, { language: language, ignoreIllegals: true }).value;
-    } catch (err) {
-      console.error(err);
-    }
-  }
-  return engine.utils.escapeHtml(code);
-};
-
-const renderCodeBlock = (code: string, language: string): string => {
-  const codeAttrs = (language !== "") ? ` class="language-${language}"` : '';
-
-  let link = "";
-  switch (language) {
-    case 'bash':
-    case 'sh':
-    case 'zsh':
-      link = `<a href="tothom://?code=${terminal.encodeTerminalCommand(code, true)}" class="tothom-code-action" title="Run in terminal">▶️</a>`;
-      break;
-    default:
-      break;
-  }
-
-  return `<pre class="hljs"><code${codeAttrs}>${syntaxHighlight(code, language)}</code>${link}</pre>`;
-};
-
+const engine = require('markdown-it');
 const taskLists = require('markdown-it-task-lists');
 const markdownItAttrs = require('markdown-it-attrs');
 
-export const engine = require('markdown-it')({
-  html: true,
-  linkify: true,
-  typographer: true,
-  highlight: renderCodeBlock
-}).use(taskLists)
-  .use(markdownItAttrs);
+const defaultRunInTerminalLabel = '▶️';
+const defaultRunInTerminalTitle = 'Run in terminal';
 
-const originalHeadingOpen = engine.renderer.rules.heading_open;
+export type RendererRuleFunc = (tokens: any[], idx: number, options: Object, env: Object, self: any) => any;
 
-const headingOpen = (): (tokens: any[], idx: number, options: Object, env: Object, self: any) => any => {
-  var slugCount = new Map<string, number>();
-
-  return (tokens: any[], idx: number, options: Object, env: Object, self: any) => {
-    const raw = tokens[idx + 1].content;
-    let slug = slugify(raw, { env });
-
-    let lastCount = slugCount.get(slug);
-    if (lastCount) {
-      lastCount++;
-      slugCount.set(slug, lastCount);
-      slug += '-' + lastCount;
-    } else {
-      slugCount.set(slug, 0);
-    }
-
-    tokens[idx].attrs = [...(tokens[idx].attrs || []), ["id", slug]];
-
-    if (originalHeadingOpen) {
-      return originalHeadingOpen(tokens, idx, options, env, self);
-    } else {
-      return self.renderToken(tokens, idx, options);
-    }
-  };
+export interface EngineOptions {
+  runInTerminalLabel?: string;
+  runInTerminalTitle?: string;
 };
 
-engine.renderer.rules.heading_open = headingOpen();
+export class Engine {
+  private _engine: any;
+  private _originalImageFunc: RendererRuleFunc;
+  private _originalHeadingOpenFunc: RendererRuleFunc;
+
+  constructor(private options?: EngineOptions) {
+    this._engine = engine({
+      html: true,
+      linkify: true,
+      typographer: true,
+      highlight: this.renderCodeBlock
+    }).use(taskLists)
+      .use(markdownItAttrs);
+
+    this._originalImageFunc = this._engine.renderer.rules.image;
+    this._originalHeadingOpenFunc = this._engine.renderer.rules.heading_open;
+    this._engine.renderer.rules.heading_open = this.headingOpen();
+  };
+
+  setOptions = (opts: EngineOptions | undefined) => this.options = opts;
+
+  render = (content: string, options?: { imageFunc?: RendererRuleFunc }): string => {
+    if (options?.imageFunc) {
+      this._engine.renderer.rules.image = options?.imageFunc;
+    }
+    const html = this._engine.render(content);
+    this._engine.renderer.rules.image = this._originalImageFunc;
+    return html;
+  };
+
+  parseInline = (text: string, env: object): any[] => {
+    return this._engine.parseInline(text, env);
+  };
+
+  private runInTerminalLabel = (): string => this.options?.runInTerminalLabel || defaultRunInTerminalLabel;
+  private runInTerminalTitle = (): string => this.options?.runInTerminalTitle || defaultRunInTerminalTitle;
+
+  private renderCodeBlock = (code: string, language: string): string => {
+    const codeAttrs = (language !== "") ? ` class="language-${language}"` : '';
+
+    let link = "";
+    switch (language) {
+      case 'bash':
+      case 'sh':
+      case 'zsh':
+        link = `<a href="tothom://?code=${terminal.encodeTerminalCommand(code, true)}" class="tothom-code-action" title="${this.runInTerminalTitle()}">${this.runInTerminalLabel()}</a>`;
+        break;
+      default:
+        break;
+    }
+
+    return `<pre class="hljs"><code${codeAttrs}>${this.syntaxHighlight(code, language)}</code>${link}</pre>`;
+  };
+
+  private syntaxHighlight = (code: string, language: string): string => {
+    if (language && hljs.getLanguage(language)) {
+      try {
+        return hljs.highlight(code, { language: language, ignoreIllegals: true }).value;
+      } catch (err) {
+        console.error(err);
+      }
+    }
+    return engine.utils.escapeHtml(code);
+  };
+
+  private headingOpen = (): RendererRuleFunc => {
+    var slugCount = new Map<string, number>();
+
+    return (tokens: any[], idx: number, options: Object, env: Object, self: any) => {
+      const raw = tokens[idx + 1].content;
+      let slug = slugify(this, raw, { env });
+
+      let lastCount = slugCount.get(slug);
+      if (lastCount) {
+        lastCount++;
+        slugCount.set(slug, lastCount);
+        slug += '-' + lastCount;
+      } else {
+        slugCount.set(slug, 0);
+      }
+
+      tokens[idx].attrs = [...(tokens[idx].attrs || []), ["id", slug]];
+
+      if (this._originalHeadingOpenFunc) {
+        return this._originalHeadingOpenFunc(tokens, idx, options, env, self);
+      } else {
+        return self.renderToken(tokens, idx, options);
+      }
+    };
+  };
+};

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,15 +1,28 @@
-import { Tothom } from './tothom';
 import * as vscode from 'vscode';
+
+import { Tothom, TothomOptions } from './tothom';
 
 const TOTHOM_MARKDOWN_PREVIEW = 'tothom.markdownPreview';
 
+const tothomOptions = (): TothomOptions => {
+  const config = vscode.workspace.getConfiguration('tothom');
+
+  return {
+    colorScheme: config.get('colorScheme'),
+    bracketedPasteMode: config.get('bracketedPasteMode'),
+    engineOptions: {
+      runInTerminalLabel: config.get('runInTerminalLabel')
+    }
+  };
+};
+
 export function activate(context: vscode.ExtensionContext) {
-  const tothom = new Tothom(context.extensionUri);
+  const tothom = new Tothom(context.extensionUri, tothomOptions());
 
   context.subscriptions.push(vscode.commands.registerCommand(TOTHOM_MARKDOWN_PREVIEW, tothom.openPreview));
 
-  vscode.workspace.onDidChangeTextDocument(event => tothom.updatePreview(event.document.uri));
-  vscode.workspace.onDidChangeConfiguration(tothom.reloadConfig);
+  vscode.workspace.onDidChangeTextDocument(event => tothom.reloadPreview(event.document.uri));
+  vscode.workspace.onDidChangeConfiguration(() => tothom.setOptions(tothomOptions()));
 }
 
 export function deactivate() {}


### PR DESCRIPTION
New configuration option `tothom.runInTerminalLabel`: `string` (default: ▶️ )

Together with:
+ major refactoring of the `Tothom` class
+ introducing new `Engine` class to replace the simpler `engine` constant

Closes #9 