### PR TITLE
New commands to bind existing terminals to the preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This file is structured according to the [Keep a Changelog](http://keepachangelo
 
 ## [Unreleased]
 
+### Added
+
+- New command <kbd>⇧ ⌘ P</kbd> _Tothom: Markdown Preview (existing terminal)_ - allows to share preexisting terminals across preview windows
+
 ## [v0.3.1] - 2022-01-04
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This file is structured according to the [Keep a Changelog](http://keepachangelo
 ### Added
 
 - New command <kbd>⇧ ⌘ P</kbd> _Tothom: Markdown Preview (existing terminal)_ - allows to share preexisting terminals across preview windows
+- New command <kbd>⇧ ⌘ P</kbd> _Tothom: Select terminal_ - allows to re-bind the active preview to an existing terminal
 
 ## [v0.3.1] - 2022-01-04
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ that gives you nice <kbd>▶️</kbd> _Run in terminal_ buttons for your code bl
 
 ## Features
 
-- Markdown preview (<kbd>⇧⌘P</kbd></kbd> _Tothom: Markdown Preview_)
+- Markdown preview (<kbd>⇧ ⌘ P</kbd></kbd> _Tothom: Markdown Preview_)
 - <kbd>▶️</kbd> _Run in terminal_ actions for code blocks (auto-generated)
 - GitHub styling
 - Syntax highlight for code blocks
@@ -15,7 +15,8 @@ that gives you nice <kbd>▶️</kbd> _Run in terminal_ buttons for your code bl
 - HTML tag attributes (with [markdown-it-attrs](https://www.npmjs.com/package/markdown-it-attrs))
 - Automatic reload of the preview on edit the source markdown file
 - Independent preview tabs for each markdown file
-- Force preview reload (<kbd>⇧⌘P</kbd></kbd> _Tothom: Reload Preview_)
+- Force preview reload (<kbd>⇧ ⌘ P</kbd></kbd> _Tothom: Reload Preview_)
+- Bind an existing terminal to a preview (a dedicated one is automatically created otherwise)
 - Native VSCode _Find_ widget enabled in the preview
 
 ## Usage
@@ -29,8 +30,16 @@ that gives you nice <kbd>▶️</kbd> _Run in terminal_ buttons for your code bl
    echo 'Hello World!'
    ```
    </pre>
-2. Run the **_Tothom: Markdown Preview_** command (<kbd>⇧⌘P</kbd></kbd>)
+2. Run the **_Tothom: Markdown Preview_** command (<kbd>⇧ ⌘ P</kbd>)
 3. Click on the <kbd>▶️</kbd> button automatically rendered with each of your code blocks, to run the code in the Visual Studio Code terminal.
+
+### Reuse a terminal
+
+Tothom binds each preview window to a terminal. When a terminal does not exist, Tothom creates a dedicated one at the time when the first <kbd>▶️</kbd> _Run in terminal_ action is executed.
+
+To bind a new preview window to a preexisting terminal, use the command <kbd>⇧ ⌘ P</kbd> _Tothom: Markdown Preview (existing terminal)_.
+
+This allows sharing a terminal across multiple preview windows.
 
 ## Extension Settings
 
@@ -41,10 +50,6 @@ that gives you nice <kbd>▶️</kbd> _Run in terminal_ buttons for your code bl
 | `tothom.runInTerminalLabel` | Label of the _Run in terminal_ button                        | Default: `▶️`                      |
 
 ## Limitations
-
-**One terminal per markdown file**<br/>
-Each preview panel gets its own dedicated terminal window. Terminal windows cannot be shared across preview panels,
-neither one preview panel can have multiple associated terminal windows.
 
 **Markdown syntax for code blocks only**<br/>
 Code block execution only works with markdown code block syntax (delimited by ```).

--- a/README.md
+++ b/README.md
@@ -37,9 +37,11 @@ that gives you nice <kbd>▶️</kbd> _Run in terminal_ buttons for your code bl
 
 Tothom binds each preview window to a terminal. When a terminal does not exist, Tothom creates a dedicated one at the time when the first <kbd>▶️</kbd> _Run in terminal_ action is executed.
 
-To bind a new preview window to a preexisting terminal, use the command <kbd>⇧ ⌘ P</kbd> _Tothom: Markdown Preview (existing terminal)_.
+To bind a new preview window to an existing terminal, use the command <kbd>⇧ ⌘ P</kbd> _Tothom: Markdown Preview (existing terminal)_.
 
-This allows sharing a terminal across multiple preview windows.
+To re-bind a preview window to an existing terminal, activate the preview and execute the command <kbd>⇧ ⌘ P</kbd> _Tothom: Select terminal_.
+
+These options allow to share a terminal across multiple preview windows.
 
 ## Extension Settings
 

--- a/package.json
+++ b/package.json
@@ -81,6 +81,11 @@
         "command": "tothom.reloadPreview",
         "title": "Reload Preview",
         "category": "Tothom"
+      },
+      {
+        "command": "tothom.selectTerminal",
+        "title": "Select terminal",
+        "category": "Tothom"
       }
     ]
   },

--- a/package.json
+++ b/package.json
@@ -73,6 +73,11 @@
         "category": "Tothom"
       },
       {
+        "command": "tothom.markdownPreviewWithExistingTerminal",
+        "title": "Markdown Preview (existing terminal)",
+        "category": "Tothom"
+      },
+      {
         "command": "tothom.reloadPreview",
         "title": "Reload Preview",
         "category": "Tothom"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,6 +6,7 @@ import { selectTerminal } from './terminal';
 const TOTHOM_MARKDOWN_PREVIEW = 'tothom.markdownPreview';
 const TOTHOM_MARKDOWN_PREVIEW_EXISTING_TERMINAL = 'tothom.markdownPreviewWithExistingTerminal';
 const TOTHOM_RELOAD_PREVIEW = 'tothom.reloadPreview';
+const TOTHOM_SELECT_TERMINAL = 'tothom.selectTerminal';
 
 const tothomOptions = (): TothomOptions => {
   const config = vscode.workspace.getConfiguration('tothom');
@@ -25,6 +26,7 @@ export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(vscode.commands.registerCommand(TOTHOM_MARKDOWN_PREVIEW, tothom.openPreview));
   context.subscriptions.push(vscode.commands.registerCommand(TOTHOM_MARKDOWN_PREVIEW_EXISTING_TERMINAL, (uri: vscode.Uri) => selectTerminal().then(term => tothom.openPreview(uri, { terminal: term }))));
   context.subscriptions.push(vscode.commands.registerCommand(TOTHOM_RELOAD_PREVIEW, tothom.reloadPreview));
+  context.subscriptions.push(vscode.commands.registerCommand(TOTHOM_SELECT_TERMINAL, (uri: vscode.Uri) => selectTerminal().then(term => tothom.bindTerminal(uri, term))));
 
   vscode.workspace.onDidChangeTextDocument(event => tothom.reloadPreview(event.document.uri, { reveal: false }));
   vscode.workspace.onDidChangeConfiguration(() => tothom.setOptions(tothomOptions()));

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,8 +1,10 @@
 import * as vscode from 'vscode';
 
 import { Tothom, TothomOptions } from './tothom';
+import { selectTerminal } from './terminal';
 
 const TOTHOM_MARKDOWN_PREVIEW = 'tothom.markdownPreview';
+const TOTHOM_MARKDOWN_PREVIEW_EXISTING_TERMINAL = 'tothom.markdownPreviewWithExistingTerminal';
 const TOTHOM_RELOAD_PREVIEW = 'tothom.reloadPreview';
 
 const tothomOptions = (): TothomOptions => {
@@ -21,6 +23,7 @@ export function activate(context: vscode.ExtensionContext) {
   const tothom = new Tothom(context.extensionUri, tothomOptions());
 
   context.subscriptions.push(vscode.commands.registerCommand(TOTHOM_MARKDOWN_PREVIEW, tothom.openPreview));
+  context.subscriptions.push(vscode.commands.registerCommand(TOTHOM_MARKDOWN_PREVIEW_EXISTING_TERMINAL, (uri: vscode.Uri) => selectTerminal().then(term => tothom.openPreview(uri, { terminal: term }))));
   context.subscriptions.push(vscode.commands.registerCommand(TOTHOM_RELOAD_PREVIEW, tothom.reloadPreview));
 
   vscode.workspace.onDidChangeTextDocument(event => tothom.reloadPreview(event.document.uri, { reveal: false }));

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -1,6 +1,9 @@
 import { window, Terminal } from 'vscode';
 
-export const findTerminal = (name: string): Terminal | undefined => {
+export const findTerminal = (name: string | undefined): Terminal | undefined => {
+  if (name === undefined) {
+    return undefined;
+  }
   return window.terminals.find(term => term.name === name);
 };
 
@@ -10,6 +13,14 @@ export const createTerminal = (name: string): Terminal => {
 
 export const findOrCreateTerminal = (name: string): Terminal => {
   return findTerminal(name) || createTerminal(name);
+};
+
+export const selectTerminal = async (): Promise<Terminal | undefined> => {
+  const item = await window.showQuickPick(window.terminals.map(term => term.name), { placeHolder: 'Select a terminal'	});
+  if (!item) {
+    return undefined;
+  }
+  return findTerminal(item);
 };
 
 export const encodeTerminalCommand = (command: string, removeComments: boolean): string => {

--- a/src/test/suite/utils.test.ts
+++ b/src/test/suite/utils.test.ts
@@ -7,9 +7,9 @@ import * as path from 'path';
 suite('Utils Test Suite', () => {
 	vscode.window.showInformationMessage('Start all tests.');
 
-	test('resource from uri', () => {
+	test('uri or active document', () => {
     const uri = vscode.Uri.parse('file:///home/user/file');
-    assert.strictEqual(utils.resourceFromUri(uri), uri);
+    assert.strictEqual(utils.uriOrActiveDocument(uri), uri);
 	});
 
   test('resource name', () => {

--- a/src/tothom.ts
+++ b/src/tothom.ts
@@ -101,6 +101,24 @@ export class Tothom {
     return webview;
   };
 
+  bindTerminal = (uri: vscode.Uri, terminal: vscode.Terminal | undefined) => {
+    const resource = uri || this.getActivePreviewUri();
+    if (resource === undefined || terminal === undefined) {
+      vscode.window.showInformationMessage('Activate a preview to select a terminal');
+      return undefined;
+    }
+
+    const preview = this._views.get(resource.fsPath);
+    if (!preview) {
+      return undefined;
+    }
+
+    if (preview.terminal?.name !== terminal.name) {
+      this._views.set(resource.fsPath, { ...preview, terminal: terminal });
+      vscode.window.showInformationMessage('Terminal bound to Tothom preview');
+    }
+  };
+
   // private methods
 
   private colorScheme = (): string => this.options?.colorScheme || defaultColorScheme;
@@ -178,7 +196,7 @@ export class Tothom {
     const term = terminal.findTerminal(preview.terminal?.name) || terminal.findOrCreateTerminal(uri.toString());
     let command = terminal.decodeTerminalCommand(encodedCommand);
 
-    this._views.set(uri.fsPath, { ...preview, terminal: term });
+    this.bindTerminal(uri, term);
 
     if (this.bracketedPasteMode()) {
       command = `\x1b[200~${command}\x1b[201~`;

--- a/src/tothom.ts
+++ b/src/tothom.ts
@@ -15,12 +15,18 @@ export interface TothomOptions {
   engineOptions?: EngineOptions;
 };
 
+interface TothomPreview {
+  uri: vscode.Uri;
+  panel: vscode.WebviewPanel;
+  terminal?: vscode.Terminal;
+}
+
 export class Tothom {
-  private _views: Map<vscode.Uri, vscode.WebviewPanel>;
+  private _views: Map<string, TothomPreview>;
   private _engine: Engine;
 
   constructor(private extensionUri: vscode.Uri, private options?: TothomOptions) {
-    this._views = new Map<vscode.Uri, vscode.WebviewPanel>;
+    this._views = new Map<string, TothomPreview>();
     this._engine = new Engine();
     this._engine.setOptions(this.options?.engineOptions);
   }
@@ -34,13 +40,13 @@ export class Tothom {
     }
   };
 
-  openPreview = (uri: vscode.Uri): vscode.Webview | undefined => {
-    const resource = utils.resourceFromUri(uri);
+  openPreview = (uri: vscode.Uri, options?: { terminal?: vscode.Terminal }): vscode.Webview | undefined => {
+    const resource = utils.uriOrActiveDocument(uri);
 
-    let panel = this._views.get(resource);
+    let preview = this._views.get(resource.fsPath);
     let webview: vscode.Webview | undefined = undefined;
 
-    if (!panel) {
+    if (!preview) {
       const title = `Preview: ${utils.resourceName(resource)}`;
 
       var localResourceRoots = [this.extensionUri];
@@ -48,18 +54,22 @@ export class Tothom {
         localResourceRoots.push(vscode.workspace.workspaceFolders[0].uri);
       }
 
-      panel = vscode.window.createWebviewPanel(WEBVIEW_PANEL_TYPE, title, vscode.ViewColumn.Active, {
+      const panel = vscode.window.createWebviewPanel(WEBVIEW_PANEL_TYPE, title, vscode.ViewColumn.Active, {
         enableScripts: true,
         enableFindWidget: true,
         retainContextWhenHidden: true,
         localResourceRoots: localResourceRoots
       });
-      panel.onDidDispose(() => this._views.delete(resource));
+      panel.onDidDispose(() => this._views.delete(resource.fsPath));
 
       webview = panel.webview;
       webview.onDidReceiveMessage(this.handleEvent);
 
-      this._views.set(resource, panel);
+      let preview: TothomPreview = { uri: resource, panel: panel };
+      if (options?.terminal) {
+        preview.terminal = options.terminal;
+      }
+      this._views.set(resource.fsPath, preview);
     }
 
     this.reloadPreview(resource);
@@ -68,11 +78,11 @@ export class Tothom {
   };
 
   reloadPreview = (uri: any, options?: { reveal?: boolean | undefined }): vscode.Webview | undefined => {
-    const resource = uri || this.getActiveViewUri() || utils.resourceFromUri(uri);
-    const panel = this._views.get(resource);
+    const resource = uri || this.getActivePreviewUri() || utils.uriOrActiveDocument(uri);
+    const preview = this._views.get(resource.fsPath);
     const reveal = !options || options.reveal || options.reveal === undefined;
 
-    if (!panel) {
+    if (!preview) {
       if (reveal) {
         vscode.window.showInformationMessage(`Tothom preview not found for resource ${utils.resourceName(resource)}`);
       }
@@ -80,10 +90,10 @@ export class Tothom {
     }
 
     if (reveal) {
-      panel.reveal(0);
+      preview.panel.reveal(0);
     }
 
-    const webview = panel.webview;
+    const webview = preview.panel.webview;
     const markdown = utils.readFileContent(resource);
     const html = this._engine.render(markdown, { imageFunc: this.renderImage(webview, resource) });
     webview.html = this.renderHtmlContent(webview, resource, html);
@@ -96,8 +106,9 @@ export class Tothom {
   private colorScheme = (): string => this.options?.colorScheme || defaultColorScheme;
   private bracketedPasteMode = (): boolean => this.options?.bracketedPasteMode || defaultBracketedPasteMode;
 
-  private getActiveViewUri = (): vscode.Uri | undefined => {
-    return [...this._views.keys()].find(key => { return this._views.get(key)?.active;});
+  private getActivePreviewUri = (): vscode.Uri | undefined => {
+    const uri = [...this._views.keys()].find(key => { return this._views.get(key)?.panel?.active; });
+    return uri ? vscode.Uri.parse(uri) : undefined;
   };
 
   private mediaFilePath = (webview: vscode.Webview, filePath: string): vscode.Uri => {
@@ -159,8 +170,15 @@ export class Tothom {
   };
 
   private runInTerminal = (encodedCommand: string, uri: vscode.Uri) => {
-    const term = terminal.findOrCreateTerminal(uri.toString());
+    const preview = this._views.get(uri.fsPath);
+    if (!preview) {
+      return undefined;
+    }
+
+    const term = terminal.findTerminal(preview.terminal?.name) || terminal.findOrCreateTerminal(uri.toString());
     let command = terminal.decodeTerminalCommand(encodedCommand);
+
+    this._views.set(uri.fsPath, { ...preview, terminal: term });
 
     if (this.bracketedPasteMode()) {
       command = `\x1b[200~${command}\x1b[201~`;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import { basename, dirname } from 'path';
 import { readFileSync } from 'fs';
 
-export const resourceFromUri = (uri: vscode.Uri): vscode.Uri => {
+export const uriOrActiveDocument = (uri: vscode.Uri): vscode.Uri => {
   let resource = uri;
   if (!(resource instanceof vscode.Uri) && vscode.window.activeTextEditor) {
     resource = vscode.window.activeTextEditor.document.uri;


### PR DESCRIPTION
New commands added:

**Tothom: Markdown Preview (existing terminal)**<br/>
Binds a new preview window to an existing terminal selected from a VSCode quick pick list. (Closes #7)

**Tothom: Select terminal**<br/>
Re-bind the active preview window to an existing terminal selected from a VSCode quick pick list. (Closes #8)

<br/>

These options allow to share a terminal across multiple preview windows.