### PR TITLE
Follow links between local markdown files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ This file is structured according to the [Keep a Changelog](http://keepachangelo
 
 - New command <kbd>⇧ ⌘ P</kbd> _Tothom: Markdown Preview (existing terminal)_ - allows to share preexisting terminals across preview windows
 - New command <kbd>⇧ ⌘ P</kbd> _Tothom: Select terminal_ - allows to re-bind the active preview to an existing terminal
+- Follow links between local markdown files - opening a new preview window automatically for each file
+
+### Fixed
+
+- Relative local image file paths required './' at the beginning of the path
 
 ## [v0.3.1] - 2022-01-04
 

--- a/README.md
+++ b/README.md
@@ -10,10 +10,11 @@ that gives you nice <kbd>▶️</kbd> _Run in terminal_ buttons for your code bl
 - GitHub styling
 - Syntax highlight for code blocks
 - Dark/light mode
+- Follow links between local markdown files
 - Anchor links
 - Tasks/TODO lists (with [markdown-it-task-lists](https://www.npmjs.com/package/markdown-it-task-lists))
 - HTML tag attributes (with [markdown-it-attrs](https://www.npmjs.com/package/markdown-it-attrs))
-- Automatic reload of the preview on edit the source markdown file
+- Automatic reload of the preview on edit of the source markdown file
 - Independent preview tabs for each markdown file
 - Force preview reload (<kbd>⇧ ⌘ P</kbd></kbd> _Tothom: Reload Preview_)
 - Bind an existing terminal to a preview (a dedicated one is automatically created otherwise)
@@ -33,7 +34,9 @@ that gives you nice <kbd>▶️</kbd> _Run in terminal_ buttons for your code bl
 2. Run the **_Tothom: Markdown Preview_** command (<kbd>⇧ ⌘ P</kbd>)
 3. Click on the <kbd>▶️</kbd> button automatically rendered with each of your code blocks, to run the code in the Visual Studio Code terminal.
 
-### Reuse a terminal
+For more examples with more markdown syntax, check the [samples](samples/tothom.md).
+
+### Re-use a terminal
 
 Tothom binds each preview window to a terminal. When a terminal does not exist, Tothom creates a dedicated one at the time when the first <kbd>▶️</kbd> _Run in terminal_ action is executed.
 

--- a/media/main.js
+++ b/media/main.js
@@ -26,11 +26,19 @@
       const node = event && event.target;
       while (node) {
         if (node.href) {
-          const href = node.getAttribute('href');
-          if (!href.startsWith('tothom')) {
-            return; // if it's not a tothom link, we don't need to worry about it
+          let href = node.getAttribute('href');
+          let command = '';
+
+          if (href.startsWith('tothom:')) {
+            command = 'run';
+          } else if (href.match(/\.md(\?.+)?$/) && !href.match(/(^file):\/\//)) {
+            href = `tothom://?p=${href}`;
+            command = 'preview';
+          } else {
+            return; // if it's neither a tothom link nor a local md file, we don't need to worry about it
           }
-          vscode.postMessage({ command: 'link', text: href + '&uri=' + document.body.dataset.uri });
+
+          vscode.postMessage({ command: command, text: href + '&uri=' + document.body.dataset.uri });
           event.preventDefault();
           return;
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,17 @@
 {
   "name": "tothom",
-  "version": "0.2.0",
+  "version": "0.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tothom",
-      "version": "0.2.0",
+      "version": "0.3.1",
       "dependencies": {
         "highlight.js": "^11.7.0",
         "markdown-it": "^13.0.1",
         "markdown-it-attrs": "^4.1.6",
-        "markdown-it-task-lists": "^2.1.1",
-        "url-parse": "^1.5.10"
+        "markdown-it-task-lists": "^2.1.1"
       },
       "devDependencies": {
         "@types/glob": "^8.0.0",
@@ -2027,11 +2026,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/querystringify": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
-    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -2114,11 +2108,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/requires-port": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
@@ -2457,15 +2446,6 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/url-parse": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
-      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
-      "dependencies": {
-        "querystringify": "^2.1.1",
-        "requires-port": "^1.0.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -4060,11 +4040,6 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
     },
-    "querystringify": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
-    },
     "queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -4123,11 +4098,6 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true
-    },
-    "requires-port": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
     },
     "resolve-from": {
       "version": "4.0.0",
@@ -4365,15 +4335,6 @@
       "dev": true,
       "requires": {
         "punycode": "^2.1.0"
-      }
-    },
-    "url-parse": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
-      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
-      "requires": {
-        "querystringify": "^2.1.1",
-        "requires-port": "^1.0.0"
       }
     },
     "util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -114,7 +114,6 @@
     "highlight.js": "^11.7.0",
     "markdown-it": "^13.0.1",
     "markdown-it-attrs": "^4.1.6",
-    "markdown-it-task-lists": "^2.1.1",
-    "url-parse": "^1.5.10"
+    "markdown-it-task-lists": "^2.1.1"
   }
 }

--- a/samples/tothom.md
+++ b/samples/tothom.md
@@ -104,10 +104,13 @@ This has a title. {title="this is the title"}
 
 ### Links
 
-- External [link](https://marketplace.visualstudio.com/items?itemName=guicassolato.tothom).
-- Linkified URL: https://github.com/guicassolato/tothom.
-- Local [link](./hello-world.md).
-- Indirect [link][1].
+- [External URL](https://marketplace.visualstudio.com/items?itemName=guicassolato.tothom)
+
+- Linkified URL: https://github.com/guicassolato/tothom
+
+- Relative local paths: [hello-world.md](hello-world.md), [../README.md](../README.md)
+
+- [Indirect link][1]
 
 [1]: https://github.com/guicassolato/tothom
 

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -62,7 +62,7 @@ export class Engine {
       case 'bash':
       case 'sh':
       case 'zsh':
-        link = `<a href="tothom://?code=${terminal.encodeTerminalCommand(code, true)}" class="tothom-code-action" title="${this.runInTerminalTitle()}">${this.runInTerminalLabel()}</a>`;
+        link = `<a href="tothom://?p=${terminal.encodeTerminalCommand(code, true)}" class="tothom-code-action" title="${this.runInTerminalTitle()}">${this.runInTerminalLabel()}</a>`;
         break;
       default:
         break;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { basename, dirname } from 'path';
+import { basename, dirname, resolve } from 'path';
 import { readFileSync } from 'fs';
 
 export const uriOrActiveDocument = (uri: vscode.Uri): vscode.Uri => {
@@ -18,16 +18,17 @@ export const resourceDir = (resource: vscode.Uri): string => {
   return dirname(resource.path);
 };
 
-export const pathToRelativeWebviewUri = (webview: vscode.Webview, resource: vscode.Uri, path: string): string => {
-  const uriBasePath = vscode.Uri.file(resourceDir(resource)).path;
-  return path.startsWith('.') ? webview.asWebviewUri(vscode.Uri.file(uriBasePath + '/' + path)).toString() : path;
+export const asWebviewUri = (localResource: string, basePath: vscode.Uri, builder: vscode.Webview): vscode.Uri => {
+  if (localResource.match(/:\/\//)) {
+    return vscode.Uri.parse(localResource); // absolute path
+  }
+  const base = vscode.Uri.file(resourceDir(basePath)).path;
+  return builder.asWebviewUri(vscode.Uri.file(resolve(base + '/' + localResource)));
 };
 
 export const readFileContent = (resource: vscode.Uri): string => {
   return readFileSync(resource.fsPath, 'utf8');
 };
-
-export const parseUrl = require('url-parse');
 
 export const getNonce = (): string => {
   let text = '';


### PR DESCRIPTION
Makes it possible to follow links to other local markdown files from a preview window.

It opens a new preview window automatically for each file, and moves back to an existing preview in case of circular references. (Closes #13)

This change also fixes a bug that required relative paths to local image files to always start with './' or the images would not load in the preview.