### PR TITLE
Bump version to v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This file is structured according to the [Keep a Changelog](http://keepachangelo
 - Option to save env variables to temporary file when running code blocks in a separate shell in the background
 - New command <kbd>⇧ ⌘ P</kbd> _Tothom: Clear terminal selection_ - removes the binding between the activate preview and a terminal
 
-## [v0.3.0] - 2022-01-05
+## [v0.4.0] - 2022-01-05
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,17 @@ This file is structured according to the [Keep a Changelog](http://keepachangelo
 
 ## [Unreleased]
 
+## [v0.5.0] - 2022-01-08
+
 ### Added
 
 - Option to default to running code blocks in a separate shell in the background instead of the in the integrated terminal. Output is appended to the preview. (Closes https://github.com/guicassolato/tothom/issues/6)
 - Option to save env variables to temporary file when running code blocks in a separate shell in the background
 - New command <kbd>⇧ ⌘ P</kbd> _Tothom: Clear terminal selection_ - removes the binding between the activate preview and a terminal
+
+### Changed
+
+- Update usage GIFs in the README
 
 ## [v0.4.0] - 2022-01-05
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Tothom",
   "description": "Yet another markdown preview with code block execution.",
   "icon": "resources/tothom.png",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "engines": {
     "vscode": "^1.74.0"
   },


### PR DESCRIPTION
Preparation to v0.5.0 release.

- fix: change v0.4.0 title
- bump package version to v0.5.0
- update CHANGELOG.md