### PR TITLE
fix: sample carrying out env across code blocks

### DIFF
--- a/samples/tothom.md
+++ b/samples/tothom.md
@@ -60,7 +60,7 @@ EOF
 ### Carrying values
 
 ```sh
-TIME="$(date)"
+export TIME="$(date)"
 ```
 
 ```sh


### PR DESCRIPTION
Variables need to be explicitly exported.