### PR TITLE
cleanup temp files created in /tmp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ This file is structured according to the [Keep a Changelog](http://keepachangelo
 
 ## [Unreleased]
 
+### Changed
+
+- Automaticaly cleanup temp files created in /tmp to carry out the envs across code blocks when running in separate shells in the background
+- Setting `tothom.saveEnvToTmp` is now called `tothom.propagateEnv` and it's enabled by default
+
 ## [v0.5.1] - 2022-01-08
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -58,20 +58,20 @@ New preview windows and preview windows not yet bound to a terminal will execute
 ![Run in background](./resources/run-in-background.gif)
 
 Keep in mind that, with this option enabled, each execution of a code block will run in an independent shell (separate child process).
-To set and re-use environment variable values across multiple code blocks, enable the `tothom.saveEnvToTmp` configuration option.
+To set and re-use environment variable values across multiple code blocks, enable the `tothom.propagateEnv` configuration option.
 
 This option is ignored if the preview is currently bound to a terminal (e.g. by using the 'Select terminal' command).
 If needed, clear the current binding of a preview to a terminal after enabling this option by activating the preview window and executing the command <kbd>⇧ ⌘ P</kbd> _Tothom: Clear terminal selection_.
 
 ## Extension Settings
 
-| Setting                           | Description                                                                                                     | Options/Default                   |
-|-----------------------------------|-----------------------------------------------------------------------------------------------------------------|-----------------------------------|
-| `tothom.bracketedPasteMode`       | Apply bracketed paste sequences on commands sent to terminal                                                    | `true` (default), `false`         |
-| `tothom.colorScheme`              | Color scheme of the preview panel                                                                               | `auto` (default), `light`, `dark` |
-| `tothom.runInTerminalLabel`       | Label of the _Run in terminal_ button                                                                           | Default: `▶️`                      |
-| `tothom.runInBackgroundByDefault` | Default to running code blocks in a separate child process in the background instead of the integrated terminal | `true`, `false` (default)         |
-| `tothom.saveEnvToTmp`             | Save and restore environment variables to temporary files around each code block execution                      | `true`, `false` (default)         |
+| Setting                           | Description                                                                                                      | Options/Default                   |
+|-----------------------------------|------------------------------------------------------------------------------------------------------------------|-----------------------------------|
+| `tothom.bracketedPasteMode`       | Apply bracketed paste sequences on commands sent to terminal                                                     | `true` (default), `false`         |
+| `tothom.colorScheme`              | Color scheme of the preview panel                                                                                | `auto` (default), `light`, `dark` |
+| `tothom.runInTerminalLabel`       | Label of the _Run in terminal_ button                                                                            | Default: `▶️`                      |
+| `tothom.runInBackgroundByDefault` | Default to running code blocks in a separate child process in the background instead of the integrated terminal  | `true`, `false` (default)         |
+| `tothom.propagateEnv`             | Propagates environment variables across executions when running code blocks in separate shells in the background | `true` (default), `false`         |
 
 ## Limitations
 

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
             "order": 10
           },
           "tothom.runInBackgroundByDefault": {
-            "markdownDescription": "Default to running code blocks in a separate shell in the background instead of in an integrated terminal window. Outputs of the executions are appended to the preview window.\n\nThis setting is ignored if the preview is bound to a terminal (e.g. by using the 'Select terminal' command).\n\nTo be able to set and re-use environment variables across code blocks when this option is active, activate as well `#tothom.saveEnvToTmp#`.",
+            "markdownDescription": "Default to running code blocks in a separate shell in the background instead of in an integrated terminal window. Outputs of the executions are appended to the preview window.\n\nThis setting is ignored if the preview is bound to a terminal (e.g. by using the 'Select terminal' command).\n\nTo be able to set and re-use environment variables across code blocks when this option is active, activate as well `#tothom.propagateEnv#`.",
             "type": "boolean",
             "default": false,
             "order": 40
@@ -72,10 +72,10 @@
             "default": "▶️",
             "order": 20
           },
-          "tothom.saveEnvToTmp": {
-            "markdownDescription": "Save and restore environment variables to temporary files (`/tmp/tothom-*.env`) around each code block execution. Only applies when `#tothom.runInBackgroundByDefault#` is enabled.",
+          "tothom.propagateEnv": {
+            "markdownDescription": "Propagates environment variable values across code block executions.\n\nIt requires access to read/write temporary files in `/tmp`.\n\nOnly applies when `#tothom.runInBackgroundByDefault#` is enabled.",
             "type": "boolean",
-            "default": false,
+            "default": true,
             "order": 50
           }
         }

--- a/samples/tothom.md
+++ b/samples/tothom.md
@@ -67,7 +67,9 @@ export TIME="$(date)"
 echo "Time was: $TIME\nTime now is: $(date)"
 ```
 
-> **Note:** `$TIME` above will be undefined when running the blocks in separate shells in the background and the `tothom.saveEnvToTmp` setting is disabled.
+```sh
+unset TIME
+```
 
 ## Compatibility
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,7 +19,7 @@ const tothomOptions = (): TothomOptions => {
       runInTerminalLabel: config.get('runInTerminalLabel')
     },
     runInBackgroundByDefault: config.get('runInBackgroundByDefault'),
-    saveEnvToTmp: config.get('saveEnvToTmp')
+    propagateEnv: config.get('propagateEnv')
   };
 };
 


### PR DESCRIPTION
- Automaticaly cleanup temp files created in /tmp to carry out the envs across code blocks when running in separate shells in the background
- Changes `tothom.saveEnvToTmp` setting to `tothom.propagateEnv`