### PR TITLE
Bump version to v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This file is structured according to the [Keep a Changelog](http://keepachangelo
 
 ## [Unreleased]
 
+## [v0.9.0] - 2023-11-27
+
 ### Fixed
 
 - Reveal active column on reload preview

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tothom",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tothom",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "dependencies": {
         "ansi_up": "^5.1.0",
         "highlight.js": "^11.7.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Tothom",
   "description": "Yet another markdown preview with code block execution.",
   "icon": "resources/tothom.png",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "engines": {
     "vscode": "^1.74.0"
   },


### PR DESCRIPTION
Preparation to v0.9.0 release.
- fix: reveal active column on preview reload
- fix: use variable instead of constant to control propagation of click event